### PR TITLE
マップで表示する領域を制限する

### DIFF
--- a/HotSpringWarrior/HotSpringWarrior/Area/Area.swift
+++ b/HotSpringWarrior/HotSpringWarrior/Area/Area.swift
@@ -11,3 +11,10 @@ protocol Area {
     var name: String { get }
     var boundary: [CLLocation] { get }
 }
+
+extension Area {
+    var boundingRect: MKMapRect {
+        let boundaryPolygon = MKPolygon(coordinates: boundary.map({ $0.coordinate }), count: boundary.count)
+        return boundaryPolygon.boundingMapRect
+    }
+}

--- a/HotSpringWarrior/HotSpringWarrior/Area/OtaArea.swift
+++ b/HotSpringWarrior/HotSpringWarrior/Area/OtaArea.swift
@@ -10,7 +10,7 @@ struct OtaArea: Area {
     var name: String = "大田区"
     
     var boundary: [CLLocation] = {
-        if let filePath = Bundle.main.path(forResource: "otaRegion", ofType: "txt") {
+        if let filePath = Bundle.main.path(forResource: "otaArea", ofType: "txt") {
             do {
                 let fileContents = try String(contentsOfFile: filePath, encoding: .utf8)
                 return AreaCSVLoader.loadCSV(data: fileContents)

--- a/HotSpringWarrior/HotSpringWarrior/ViewController/GameViewController.swift
+++ b/HotSpringWarrior/HotSpringWarrior/ViewController/GameViewController.swift
@@ -25,10 +25,13 @@ class GameViewController: UIViewController {
         mapView = MKMapView(frame: .zero)
         mapView.showsUserLocation = true
         mapView.delegate = self
-        mapView.isRotateEnabled = false
-        mapView.isPitchEnabled = false
-        mapView.isScrollEnabled = false
-        mapView.isZoomEnabled = false
+        mapView.setRegion(.init(eventArea.boundingRect), animated: true)
+        mapView.setCameraBoundary(.init(mapRect: eventArea.boundingRect), animated: true)
+//        200は適当に付けてるだけ
+//        widthやheightをmaxCenterCoordinateDistanceに設定するとAreaもう一個分だけ移動できるようになる.
+//        今回はそこまで移動できても意味がないので半分だけ余白を持たせている。
+        mapView.setCameraZoomRange(.init(minCenterCoordinateDistance: 200,maxCenterCoordinateDistance: min(eventArea.boundingRect.width, eventArea.boundingRect.height)*0.5), animated: true)
+        mapView.pointOfInterestFilter = MKPointOfInterestFilter(including: [])
         mapView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(mapView)
         


### PR DESCRIPTION
close #10 
```
mapView.setRegion(.init(eventArea.boundingRect), animated: true)
```
見える部分を指定する
```
mapView.setCameraBoundary(.init(mapRect: eventArea.boundingRect), animated: true)
```
表示可能領域を設定
上の設定だとbounrRectの4つの頂点がそれぞれ、画面の中心にくるところまでは移動できる。
```
mapView.setCameraZoomRange(.init(minCenterCoordinateDistance: 200,maxCenterCoordinateDistance: min(eventArea.boundingRect.width, eventArea.boundingRect.height)*0.5), animated: true)
```
表示可能な範囲をもとにzoom可能な範囲を設定する。
setCameraBoundaryとともに最終的に見ることができる範囲が決定される。
